### PR TITLE
Tweaks to build with MinGW

### DIFF
--- a/Tester/Tester.epj
+++ b/Tester/Tester.epj
@@ -1,0 +1,61 @@
+{
+   "Version" : 0.2,
+   "ModuleName" : "Tester",
+   "Options" : {
+      "Warnings" : "All",
+      "PreprocessorDefinitions" : [
+         "GLM_FORCE_PURE"
+      ],
+      "IncludeDirs" : [
+         "../VEngineNative"
+      ],
+      "TargetType" : "Executable",
+      "TargetFileName" : "Tester",
+      "Libraries" : [
+         "VEngineNative",
+         "glfw3"
+      ],
+      "LibraryDirs" : [
+         "../glfw-3.2/obj/release.$(PLATFORM)",
+         "../VEngineNative/obj/release.$(PLATFORM)"
+      ]
+   },
+   "Platforms" : [
+      {
+         "Name" : "win32",
+         "Options" : {
+            "Libraries" : [
+               "imm32"
+            ]
+         }
+      }
+   ],
+   "Configurations" : [
+      {
+         "Name" : "Debug",
+         "Options" : {
+            "Debug" : true,
+            "Optimization" : "None",
+            "PreprocessorDefinitions" : [
+               "_DEBUG"
+            ],
+            "FastMath" : false
+         }
+      },
+      {
+         "Name" : "Release",
+         "Options" : {
+            "Debug" : false,
+            "Optimization" : "Speed",
+            "FastMath" : true
+         }
+      }
+   ],
+   "Files" : [
+      "Tester.cpp"
+   ],
+   "ResourcesPath" : "",
+   "Resources" : [
+
+   ]
+}

--- a/VEngineNative/Game.cpp
+++ b/VEngineNative/Game.cpp
@@ -1,6 +1,21 @@
+#if !defined(_MSC_VER)
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#endif
+
 #include "stdafx.h"
+
+#if defined(_MSC_VER)
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+#endif
+
 #include "Game.h"
 #include "imgui_impl_glfw_gl3.h"
+
+#if !defined(_MSC_VER)
+#define strcpy_s strcpy
+#endif
 
 Game * Game::instance = nullptr;
 
@@ -9,7 +24,7 @@ Game::Game(int windowwidth, int windowheight)
     instance = this;
     width = windowwidth;
     height = windowheight;
-    invokeQueue = {};
+    invokeQueue = std::queue<std::function<void()> > {};
     onRenderFrame = {};
     asset = new AssetLoader();
     world = new World();

--- a/VEngineNative/Game.h
+++ b/VEngineNative/Game.h
@@ -6,9 +6,6 @@
 #include "AssetLoader.h";
 #include "EventHandler.h";
 
-#define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
-
 class Game
 {
 public:

--- a/VEngineNative/Media.cpp
+++ b/VEngineNative/Media.cpp
@@ -48,7 +48,7 @@ string Media::readString(string key)
 string Media::getPath(string key)
 {
     if (mediaMap.find(key) == mediaMap.end())
-        throw sprintf("File %s not found in media map", key.c_str());
+        throw printf("File %s not found in media map", key.c_str());
     return mediaMap.at(key);
 }
 

--- a/VEngineNative/Media.h
+++ b/VEngineNative/Media.h
@@ -6,7 +6,7 @@ public:
     static void loadFileMap(string path);
     static string readString(string key);
     static string getPath(string key);
-    static int Media::readBinary(string key, unsigned char** out_bytes);
+    static int readBinary(string key, unsigned char** out_bytes);
     static void saveCache(string key, void* data);
     static void* checkCache(string key);
 

--- a/VEngineNative/Texture.h
+++ b/VEngineNative/Texture.h
@@ -12,7 +12,7 @@ public:
     int components;
     int width, height;
     void use(int unit);
-    void Texture::bind(int unit, int level);
+    void bind(int unit, int level);
     void pregenerate();
     void generateMipMaps();
 private:

--- a/VEngineNative/VEngineNative.epj
+++ b/VEngineNative/VEngineNative.epj
@@ -1,0 +1,148 @@
+{
+   "Version" : 0.2,
+   "ModuleName" : "VEngineNative",
+   "Options" : {
+      "Warnings" : "All",
+      "PreprocessorDefinitions" : [
+         "GLM_FORCE_PURE"
+      ],
+      "IncludeDirs" : [
+         "."
+      ],
+      "TargetType" : "StaticLibrary",
+      "TargetFileName" : "VEngineNative"
+   },
+   "Platforms" : [
+      {
+         "Name" : "win32",
+         "Options" : {
+            "Libraries" : [
+               "imm32"
+            ]
+         }
+      }
+   ],
+   "Configurations" : [
+      {
+         "Name" : "Debug",
+         "Options" : {
+            "Debug" : true,
+            "Optimization" : "None",
+            "PreprocessorDefinitions" : [
+               "_DEBUG"
+            ],
+            "FastMath" : false
+         },
+         "Platforms" : [
+            {
+               "Name" : "win32",
+               "Options" : {
+                  "Libraries" : [
+                     "imm32",
+                     "gdi32"
+                  ]
+               }
+            }
+         ]
+      },
+      {
+         "Name" : "Release",
+         "Options" : {
+            "Debug" : false,
+            "Optimization" : "Speed",
+            "FastMath" : true
+         }
+      }
+   ],
+   "Files" : [
+      {
+         "Folder" : "src",
+         "Files" : [
+            "./AbsTransformable.cpp",
+            "./AbsTransformable.h",
+            "./AssetLoader.cpp",
+            "./AssetLoader.h",
+            "./Camera.cpp",
+            "./Camera.h",
+            "./CubeMapFramebuffer.cpp",
+            "./CubeMapFramebuffer.h",
+            "./CubeMapTexture.cpp",
+            "./CubeMapTexture.h",
+            "./EnvProbe.cpp",
+            "./EnvProbe.h",
+            "./EventHandler.h",
+            "./Framebuffer.cpp",
+            "./Framebuffer.h",
+            "./FrustumCone.cpp",
+            "./FrustumCone.h",
+            "./Game.cpp",
+            "./Game.h",
+            "./GenericShaders.cpp",
+            "./GenericShaders.h",
+            "./glad.cpp",
+            "./glad.h",
+            "./glfw.h",
+            "./imgui_impl_glfw_gl3.cpp",
+            "./imgui_impl_glfw_gl3.h",
+            "./khrplatform.h",
+            "./Light.cpp",
+            "./Light.h",
+            "./Material.cpp",
+            "./Material.h",
+            "./MaterialNode.cpp",
+            "./MaterialNode.h",
+            "./Media.cpp",
+            "./Media.h",
+            "./Mesh3d.cpp",
+            "./Mesh3d.h",
+            "./Mesh3dInstance.cpp",
+            "./Mesh3dInstance.h",
+            "./Mesh3dLodLevel.cpp",
+            "./Mesh3dLodLevel.h",
+            "./Object3dInfo.cpp",
+            "./Object3dInfo.h",
+            "./Object3dManager.cpp",
+            "./Object3dManager.h",
+            "./Renderer.cpp",
+            "./Renderer.h",
+            "./Scene.cpp",
+            "./Scene.h",
+            "./ShaderProgram.cpp",
+            "./ShaderProgram.h",
+            "./ShaderStorageBuffer.cpp",
+            "./ShaderStorageBuffer.h",
+            "./stb_image.h",
+            "./stdafx.cpp",
+            "./stdafx.h",
+            "./targetver.h",
+            "./Texture.cpp",
+            "./Texture.h",
+            "./Texture3d.cpp",
+            "./Texture3d.h",
+            "./tinydir.h",
+            "./TransformationManager.cpp",
+            "./TransformationManager.h",
+            "./World.cpp",
+            "./World.h"
+         ]
+      },
+      {
+         "Folder" : "imgui",
+         "Files" : [
+            "imconfig.h",
+            "imgui.cpp",
+            "imgui.h",
+            "imgui_demo.cpp",
+            "imgui_draw.cpp",
+            "imgui_internal.h",
+            "stb_rect_pack.h",
+            "stb_textedit.h",
+            "stb_truetype.h"
+         ]
+      }
+   ],
+   "ResourcesPath" : "",
+   "Resources" : [
+
+   ]
+}

--- a/VEngineNative/gli/gli.hpp
+++ b/VEngineNative/gli/gli.hpp
@@ -30,6 +30,10 @@
 #define GLI_VERSION_PATCH			1
 #define GLI_VERSION_REVISION		0
 
+#if !defined(_MSC_VER)
+#define fopen_s(a, b, c) (*(a) = fopen(b, c), *(a) != 0)
+#endif
+
 /// Namespace where all the classes and functions provided by GLI are exposed
 namespace gli
 {

--- a/shaders/postprocessing/Combine.fragment.glsl
+++ b/shaders/postprocessing/Combine.fragment.glsl
@@ -40,7 +40,7 @@ float aaoo(){
     for(int i=0;i<32;i++){
         vec2 rdp = randpoint2() * 0.01;
         float there = texture(cloudsCloudsTex, uv + rdp).b;
-        float w = 1.0 - smoothstep(1000.0, 10000, center - there);
+        float w = 1.0 - smoothstep(1000.0, 10000.0, center - there);
         aoc += w * clamp(center - there, 0.0, 1000.0) * 0.001;
     }
     return pow(1.0 - aoc / 32.0, 16.0);
@@ -123,7 +123,7 @@ float noise2X( in vec2 x ){
         );
     return res;
 }
-#define ssin(a) (smoothstep(0,3.1415,a*3.1415) * 2.0 - 1.0) 
+#define ssin(a) (smoothstep(0.0,3.1415,a*3.1415) * 2.0 - 1.0) 
 #define snoisesin(a) pow(1.0 - (abs(noise2X(a) - 0.5) * 2.0), 6.0)
 #define snoisesinpow(a,b) pow(1.0 - (abs(noise2X(a) - 0.5) * 2.0), b)
 #define snoisesinpowXF(a,b) (1.0 - pow((abs(snoise(a))), b))
@@ -237,7 +237,7 @@ vec3 cloudsbydir(vec3 dir){
         roughness = 1.0 - pow(roughness, 164.0);
         roughness = mix(roughness, 1.0, 1.0 - pow(abs(dir.y), 1.0));
         dst = planethit;
-        float lodz = pow(1.0 - smoothstep(0, LOD3, planethit), 4.0);
+        float lodz = pow(1.0 - smoothstep(0.0, LOD3, planethit), 4.0);
         vec3 n = vec3(0,1,0);
         float waveheight = 0.0;
         if(WaterWavesScale > 0.0){
@@ -245,7 +245,7 @@ vec3 cloudsbydir(vec3 dir){
                 n = raymarchwaterLOW3(newpos, newpos2);
             }
             else {
-                n = mix(raymarchwaterLOW3(newpos, newpos2), raymarchwater(newpos, newpos2, int(2.0 + 6.0 * lodz * WaterWavesScale), int(2.0 + 8.0 * lodz * WaterWavesScale)), 1.0 - smoothstep(0, LOD3, planethit));
+                n = mix(raymarchwaterLOW3(newpos, newpos2), raymarchwater(newpos, newpos2, int(2.0 + 6.0 * lodz * WaterWavesScale), int(2.0 + 8.0 * lodz * WaterWavesScale)), 1.0 - smoothstep(0.0, LOD3, planethit));
             }
             float freq = 1.0;
             float h0 = heightwater(hitpos.xz, WATER_SAMPLES_HIGH-3);
@@ -256,7 +256,7 @@ vec3 cloudsbydir(vec3 dir){
             float h4 = heightwater(hitpos.xz - vec2(0.0, freq), WATER_SAMPLES_HIGH-3);
             whites = max(0, h0 - (h1 + h2 + h3 + h4)*0.25) * 122.0 * pow(h0, 3.0);
             whites = min(1.0, pow(whites, 3.0));
-            whites *= (1.0 - smoothstep(0, LOD3, planethit)) * WaterWavesScale;
+            whites *= (1.0 - smoothstep(0.0, LOD3, planethit)) * WaterWavesScale;
             //return vec3(whites);
             float lodzx =  1.0 - clamp(hitdistx / LOD3, 0.0, 1.0);
             //roughness = roughness * 0.8 + 0.2;


### PR DESCRIPTION
- Work around for strcpy_s, fopen_s
- Moved inclusion of stb_image.h for non-MSC which was causing unresolved symbols
- Removed extra [class]:: in class declarations
- Fixed call to sprintf intended to be printf in exception throw
- Fixed GLSL shaders ambiguous float/int
- Added project files for Ecere IDE
